### PR TITLE
Entity Metadata Wrapper

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -1,0 +1,300 @@
+package com.comphenix.packetwrapper;
+
+import org.bukkit.ChatColor;
+
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+
+/**
+ * A useful wrapper for the Wrapped Data Watcher class, easy to understand and use
+ * To be used in the setMetadata(EntityMetadata value) method to set a entity's metadata
+ * 
+ * YOU MUST SET AT LEAST ONE TYPE OF METADATA OR USERS WILL CRASH APON ENTITY SPAWN
+ * 
+ * You must also have a basic understanding of bitmasking to use this class
+ * 
+ * @author Quantum64
+ */
+public class EntityMetadata extends WrappedDataWatcher {
+
+	/**
+	 * Index: 0
+	 * Type: Entity
+	 * Use: Set entity flags as byte
+	 * @param flags - Entity flags bit mask: 
+	 * 0x01 = On Fire 
+	 * 0x02	= Crouched
+	 * 0x08 = Sprinting
+	 * 0x10 = Eating/Drinking/Blocking
+	 * 0x20	 Invisible
+	 */
+	public void setFlags(byte flags) {
+		this.setObject(0, flags);
+	}
+
+	/**
+	 * Index: 1
+	 * Type: Entity
+	 * Use: Current time in air - only used in game for Falling Sand Entity
+	 * @param air - Current time in air
+	 */
+	public void setAir(short air) {
+		this.setObject(1, air);
+	}
+
+	/**
+	 * Index: 6
+	 * Type: Living Entity
+	 * Use: Sets the living Entity's health
+	 * @param health - health of mob as a float
+	 */
+	public void setHealth(float health) {
+		this.setObject(6, health);
+	}
+
+	/**
+	 * Index: 7
+	 * Type: Living Entity
+	 * Use: Set the potion effect color for the Living Entity
+	 * @param color -  color of potion effect particals
+	 */
+	public void setPotionEffectColor(int color) {
+		this.setObject(7, color);
+	}
+
+	/**
+	 * Index: 8
+	 * Type: Living Entity
+	 * Use: Sets if the potion effect particals are visible or not
+	 * @param value - byte 1 or 0 (see potion effect particals = 1, no potion effect particals = 0)
+	 */
+	public void setPotionEffectAmbient(byte value) {
+		this.setObject(8, value);
+	}
+
+	public void setNumArrowsInEntity(byte arrows) {
+		this.setObject(9, arrows);
+	}
+
+	public void setNameTag(String nameTag) {
+		this.setObject(10, ChatColor.translateAlternateColorCodes('&', nameTag));
+	}
+
+	public void setAlwaysShowNameTag(byte value) {
+		this.setObject(11, value);
+	}
+
+	public void setEntityAge(int age) {
+		this.setObject(12, age);
+	}
+
+	public void setHorseFlags(int flags) {
+		this.setObject(16, flags);
+	}
+
+	public void setHorseType(byte type) {
+		this.setObject(19, type);
+	}
+
+	public void setHorseColorAndTexture(int value) {
+		this.setObject(20, value);
+	}
+
+	public void setHorseOwnerName(String name) {
+		this.setObject(21, name);
+	}
+
+	public void setBatHanging(byte hanging) {
+		this.setObject(16, hanging);
+	}
+
+	public void setTame(byte tame) {
+		this.setObject(16, tame);
+	}
+
+	public void setOwnersName(String name) {
+		this.setObject(17, name);
+	}
+
+	public void setOcelotType(byte type) {
+		this.setObject(18, type);
+	}
+
+	public void setWolfFlags(byte flags) {
+		this.setObject(18, flags);
+	}
+
+	public void setWolfHealth(float health) {
+		this.setObject(18, health);
+	}
+
+	public void setWolfBegging(byte begging) {
+		this.setObject(18, begging);
+	}
+
+	public void setWolfCollarColor(byte color) {
+		this.setObject(18, color);
+	}
+
+	public void setHasSaddle(byte value) {
+		this.setObject(18, value);
+	}
+
+	public void setSheepFlags(byte flags) {
+		this.setObject(18, flags);
+	}
+
+	public void setVillagerType(byte type) {
+		this.setObject(18, type);
+	}
+
+	public void setEndermanBlock(byte block) {
+		this.setObject(18, block);
+	}
+
+	public void setEndermanBlockData(byte blockData) {
+		this.setObject(18, blockData);
+	}
+
+	public void setEndermanScreaming(byte value) {
+		this.setObject(18, value);
+	}
+
+	public void setZombieChid(byte child) {
+		this.setObject(18, child);
+	}
+
+	public void setZombieVillager(byte villager) {
+		this.setObject(18, villager);
+	}
+
+	public void setZombieConverting(byte converting) {
+		this.setObject(18, converting);
+	}
+
+	public void setBlazeOnFire(byte onFire) {
+		this.setObject(18, onFire);
+	}
+
+	public void setSpiderClimbing(byte climbing) {
+		this.setObject(18, climbing);
+	}
+
+	public void setCreeperState(byte flags) {
+		this.setObject(18, flags);
+	}
+
+	public void setCreeperCharged(byte charged) {
+		this.setObject(18, charged);
+	}
+
+	public void setGhastAttacking(byte attacking) {
+		this.setObject(18, attacking);
+	}
+
+	public void setSlimeSlze(byte size) {
+		this.setObject(18, size);
+	}
+
+	public void setMagmaCubeSize(byte size) {
+		this.setObject(18, size);
+	}
+
+	public void setSkeletonType(byte type) {
+		this.setObject(18, type);
+	}
+
+	public void setWitchAgro(byte agro) {
+		this.setObject(18, agro);
+	}
+
+	public void setIronGolemPlayerCreated(byte value) {
+		this.setObject(18, value);
+	}
+
+	public void setWitherHeadTarget1(int target) {
+		this.setObject(18, target);
+	}
+
+	public void setWitherHeadTarget2(int target) {
+		this.setObject(18, target);
+	}
+
+	public void setWitherHeadTarget3(int target) {
+		this.setObject(18, target);
+	}
+
+	public void setWitherInvulnerableTime(int time) {
+		this.setObject(18, time);
+	}
+
+	public void setBoatTimeSinceHit(int time) {
+		this.setObject(18, time);
+	}
+
+	public void setBoatFowardDirection(int dir) {
+		this.setObject(18, dir);
+	}
+
+	public void setBoatDamage(int damage) {
+		this.setObject(18, damage);
+	}
+
+	public void setMinecraftShakingPower(int power) {
+		this.setObject(18, power);
+	}
+
+	public void setMinecartSkakeingDirection(int dir) {
+		this.setObject(18, dir);
+	}
+
+	public void setMinecartDamage(float damage) {
+		this.setObject(18, damage);
+	}
+
+	public void setBlockInMinecart(int block) {
+		this.setObject(18, block);
+	}
+
+	public void setMinecraftBlockYOffest(int y) {
+		this.setObject(18, y);
+	}
+	
+	public void setShowMinecartBlock(byte value){
+		this.setObject(18, value);
+	}
+
+	public void setFurnaceMinecartPowered(byte powered) {
+		this.setObject(18, powered);
+	}
+
+	/**
+	 * ProtocolLib does not yet support this function
+	 */
+	public void setItem() {
+	}
+
+	public void setArrowCriticalHit(byte value) {
+		this.setObject(18, value);
+	}
+
+	/**
+	 * ProtocolLib does not yet support this function
+	 */
+	public void setFireworkInfo() {
+	}
+	
+	/**
+	 * ProtocolLib does not yet support this function
+	 */
+	public void setItemFrameItem() {
+	}
+
+	public void setItemFrameRotation() {
+		this.setObject(18, type);
+	}
+
+	public void setEnderCrystalAlive() {
+		this.setObject(18, type);
+	}
+
+}

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -7,11 +7,11 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 
 /**
  * A useful wrapper for the Wrapped Data Watcher class, easy to understand and use
- * To be used in the setMetadata(EntityMetadata value) method to set a entity's metadata
+ * To be used in the setMetadata(this.getMetadata()) method to set a entity's metadata
  * 
  * YOU MUST SET AT LEAST ONE TYPE OF METADATA OR USERS WILL CRASH APON ENTITY SPAWN
  * 
- * You must also have a basic understanding of bitmasking to use this class
+ * Multiple (type, color, etc...) options generally offer enums, or can be written directly
  * 
  * @author Quantum64
  */
@@ -20,6 +20,10 @@ public class EntityMetadata {
 
 	private WrappedDataWatcher metadata;
 
+	/**
+	 * Use: Gets the final metadata for use in the setMetadata(WrappedDataWatcher value) method
+	 * @return WrappedDataWatcher - final metadata set
+	 */
 	public WrappedDataWatcher getMetadata() {
 		return metadata;
 	}
@@ -40,6 +44,44 @@ public class EntityMetadata {
 	}
 
 	/**
+	 * Index: 0
+	 * Type: Entity
+	 * Use: Set entity flags as EntityFlags enum option
+	 * @param flags - EntityFlags as an enum
+	 */
+	public void setFlags(EntityFlags flags) {
+		byte a;
+		switch (flags) {
+		case ON_FIRE:
+			a = 0x01 & 0x01;
+			break;
+		case CROUCHED:
+			a = 0x01 & 0x02;
+			break;
+		case SPRINTING:
+			a = 0x01 & 0x08;
+			break;
+		case EATING_DRINKING_BLOCKING:
+			a = 0x01 & 0x10;
+			break;
+		case INVISIBLE:
+			a = 0x01 & 0x20;
+			break;
+		default:
+			a = 0;
+		}
+		setMeta(0, a);
+	}
+
+	/**
+	 * Use: Used with the setFlags(EntityFlags flags) method
+	 * Contains: Options for entity flags (basic data)
+	 */
+	public enum EntityFlags {
+		ON_FIRE, CROUCHED, SPRINTING, EATING_DRINKING_BLOCKING, INVISIBLE
+	}
+
+	/**
 	 * Index: 1
 	 * Type: Entity
 	 * Use: Current time in air - only used in game for Falling Sand Entity
@@ -49,14 +91,36 @@ public class EntityMetadata {
 		setMeta(1, air);
 	}
 
+	/**
+	 * Index: 0
+	 * Type: Entity
+	 * Use: Get entity flags as byte
+	 * @return flags - Entity flags bit mask: (flags as byte, cast if needed)
+	 * 0x01 = On Fire      
+	 * 0x02	= Crouched      
+	 * 0x08 = Sprinting     
+	 * 0x10 = Eating/Drinking/Blocking      
+	 * 0x20	 Invisible     
+	 */
 	public Object getFlags() {
 		return getMeta(0);
 	}
 
+	/**
+	 * Index: 1
+	 * Type: Entity
+	 * Use: Current time in air - only used in game for Falling Sand Entity
+	 * @return air - Current time in air (as a short, cast if needed)
+	 */
 	public Object getAir() {
 		return getMeta(1);
 	}
 
+	/**
+	 * 
+	 * Represents the Metadata of a Living Entity
+	 *
+	 */
 	public static class LivingEntityMetadata extends EntityMetadata {
 		/**
 		 * Index: 6
@@ -71,7 +135,7 @@ public class EntityMetadata {
 		/**
 		 * Index: 7
 		 * Type: Living Entity
-		 * Use: Set the potion effect color for the Living Entity
+		 * Use: Set the potion effect color for the Living Entity (Do not assign if you are not going to use potion effect particals!)
 		 * @param color -  color of potion effect particals
 		 */
 		public void setPotionEffectColor(int color) {
@@ -81,56 +145,114 @@ public class EntityMetadata {
 		/**
 		 * Index: 8
 		 * Type: Living Entity
-		 * Use: Sets if the potion effect particals are visible or not
+		 * Use: Sets if the potion effect particals are visible or not (required feild for a Named Entity, set to zero if you do not want potion effect particals)
 		 * @param value - byte 1 or 0 (see potion effect particals = 1, no potion effect particals = 0)
 		 */
 		public void setPotionEffectAmbient(byte value) {
 			setMeta(8, value);
 		}
 
+		/**
+		 * Index: 9
+		 * Type: Living Entity
+		 * Use: Sets number of arrows in entity, client will crash if it is more than 254, or less than 1 (do not assign if 0)
+		 * @param arrows - number of arrows in entity
+		 */
 		public void setNumArrowsInEntity(byte arrows) {
 			setMeta(9, arrows);
 		}
 
+		/**
+		 * Index: 10
+		 * Type: Living Entity
+		 * Use: Sets the name (name tag) of the entity
+		 * @param nameTag - Name of Living Entity as a String use '&' for color codes
+		 */
 		public void setNameTag(String nameTag) {
 			setMeta(10, ChatColor.translateAlternateColorCodes('&', nameTag));
 		}
 
+		/**
+		 * Index: 11
+		 * Type: Living Entity
+		 * Use: Sets if the name tag of the entity is always visible, even if the player is not looking directly at it
+		 * If spawning a Named Entity (Player) the name tag is always visible regardless of this option
+		 * @param value - Always see name tag even if not looking at entity (as a byte 0 = false, 1 = true)
+		 */
 		public void setAlwaysShowNameTag(byte value) {
 			setMeta(11, value);
 		}
 
+		/**
+		 * @return health - returns the health of the Living Entity (as a float, cast if needed)
+		 */
 		public Object getHealth() {
 			return getMeta(6);
 		}
 
+		/**
+		 * Use: Get the color of the potion effect particals of the Living Entity 
+		 * @return color - color of potion effect particals (as an int, cast if needed)
+		 */
 		public Object getPotionEffectColor() {
 			return getMeta(7);
 		}
 
+		/**
+		 * 
+		 * @return value - returns if the potion effect particals are visible (as a byte 0 = false, 1 = true)
+		 */
 		public Object getPotionEffectAmbient() {
 			return getMeta(8);
 		}
 
+		/**
+		 * 
+		 * @return arrows - the number of arrows in the entity (as an byte, cast if needed)
+		 */
 		public Object getNumArrowsInEntity() {
 			return getMeta(9);
 		}
 
+		/**
+		 * 
+		 * @return name - the name (name tag) of the Living Entity (as a String, cast if needed)
+		 */
 		public Object getNameTag() {
 			return getMeta(10);
 		}
 
+		/**
+		 * 
+		 * @return value - Always see name tag even if not looking at entity (as a byte 0 = false, 1 = true)
+		 */
 		public Object getAlwaysShowNameTag() {
 			return getMeta(11);
 		}
 
 	}
 
+	/**
+	 * 
+	 * Represents an Ageable metadata - extends Living Entity
+	 * Ageable - can be a child or adult
+	 *
+	 */
 	public static class AgeableMetadata extends LivingEntityMetadata {
+		/**
+		 * Index: 12
+		 * Type: Ageable
+		 * Use: Set the Ageable Entity's age (this effects how soon the entity will grow, age = time adult, really)
+		 * @param age - Entity's Age (Negative = Child)
+		 */
 		public void setEntityAge(int age) {
 			setMeta(12, age);
 		}
 
+		/**
+		 * 
+		 * @return age - returns the entity's age (as an int, cast if needed)
+		 */
 		public Object getEntityAge() {
 			return getMeta(12);
 		}
@@ -139,6 +261,39 @@ public class EntityMetadata {
 	public static class HorseMetadata extends AgeableMetadata {
 		public void setHorseFlags(int flags) {
 			setMeta(16, flags);
+		}
+
+		public void setHorseFLags(HorseFlags flags) {
+			int a;
+			switch (flags) {
+			case IS_TAME:
+				a = 0x01 & 0x02;
+				break;
+			case HAS_SADDLE:
+				a = 0x01 & 0x04;
+				break;
+			case HAS_CHEST:
+				a = 0x01 & 0x08;
+			case IS_BRED:
+				a = 0x01 & 0x10;
+				break;
+			case IS_EATING:
+				a = 0x01 & 0x20;
+				break;
+			case IS_REARING:
+				a = 0x01 & 0x40;
+				break;
+			case MOUTH_OPEN:
+				a = 0x01 & 0x80;
+				break;
+			default:
+				a = 0;
+			}
+			setMeta(16, a);
+		}
+
+		public enum HorseFlags {
+			IS_TAME, HAS_SADDLE, HAS_CHEST, IS_BRED, IS_EATING, IS_REARING, MOUTH_OPEN
 		}
 
 		public void setHorseType(byte type) {

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -312,7 +312,7 @@ public class EntityMetadata {
 			return getMeta(16);
 		}
 
-		public Object getHorgetype() {
+		public Object getHorseType() {
 			return getMeta(19);
 		}
 

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -18,7 +18,7 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 
 public class EntityMetadata {
 
-	private WrappedDataWatcher metadata;
+	protected WrappedDataWatcher metadata;
 
 	/**
 	 * Use: Gets the final metadata for use in the setMetadata(WrappedDataWatcher value) method
@@ -26,6 +26,138 @@ public class EntityMetadata {
 	 */
 	public WrappedDataWatcher getMetadata() {
 		return metadata;
+	}
+
+	public static EntityMetadata newEntityMetadata() {
+		return new EntityMetadata();
+	}
+
+	public static LivingEntityMetadata newLivingEntityMetadata() {
+		return new LivingEntityMetadata();
+	}
+
+	public static AgeableMetadata newAgeableMetadata() {
+		return new AgeableMetadata();
+	}
+
+	public static HorseMetadata newHorseMetadata() {
+		return new HorseMetadata();
+	}
+
+	public static BatMetadata newBatMetadata() {
+		return new BatMetadata();
+	}
+
+	public static TameableMetadata newTameableMetadata() {
+		return new TameableMetadata();
+	}
+
+	public static OcelotMetadata newOcelotMetadata() {
+		return new OcelotMetadata();
+	}
+
+	public static WolfMetadata newWolfMetadata() {
+		return new WolfMetadata();
+	}
+
+	public static PigMetadata newPigMetadata() {
+		return new PigMetadata();
+	}
+
+	public static SheepMetadata newSheepMetadata() {
+		return new SheepMetadata();
+	}
+
+	public static VillagerMetadata newVillagerMetadata() {
+		return new VillagerMetadata();
+	}
+
+	public static EndermanMetadata newEndermanMetadata() {
+		return new EndermanMetadata();
+	}
+
+	public static ZombieMetadata newZombieMetadata() {
+		return new ZombieMetadata();
+	}
+
+	public static PigZombieMetadata newPigZombieMetadata() {
+		return new PigZombieMetadata();
+	}
+
+	public static BlazeMetadata newBlazeMetadata() {
+		return new BlazeMetadata();
+	}
+
+	public static SpiderMetadata newSpiderMetadata() {
+		return new SpiderMetadata();
+	}
+
+	public static CaveSpiderMetadata newCaveSpiderMetadata() {
+		return new CaveSpiderMetadata();
+	}
+
+	public static CreeperMetadata newCreeperMetadata() {
+		return new CreeperMetadata();
+	}
+
+	public static GhastMetadata newGhastMetadata() {
+		return new GhastMetadata();
+	}
+
+	public static SlimeMetadata newSlimeMetadata() {
+		return new SlimeMetadata();
+	}
+
+	public static MagmaCubeMetadata newMagmaCubeMetadata() {
+		return new MagmaCubeMetadata();
+	}
+
+	public static SkeletonMetadata newSkeletonMetadata() {
+		return new SkeletonMetadata();
+	}
+
+	public static WitchMetadata newWitchMetadata() {
+		return new WitchMetadata();
+	}
+
+	public static IronGolemMetadata newIronGolemMetadata() {
+		return new IronGolemMetadata();
+	}
+
+	public static WitherMetadata newWitherMetadata() {
+		return new WitherMetadata();
+	}
+
+	public static BoatMetadata newBoatMetadata() {
+		return new BoatMetadata();
+	}
+
+	public static MinecartMetadata newMinecartMetadata() {
+		return new MinecartMetadata();
+	}
+
+	public static FurnaceMinecartMetadata newFurnaceMinecartMetadata() {
+		return new FurnaceMinecartMetadata();
+	}
+
+	public static ItemMetadata newItemMetadata() {
+		return new ItemMetadata();
+	}
+
+	public static ArrowMetadata newArrowMetadata() {
+		return new ArrowMetadata();
+	}
+
+	public static FireworkMetadata newFireworkMetadata() {
+		return new FireworkMetadata();
+	}
+
+	public static ItemFrameMetadata newItemFrameMetadata() {
+		return new ItemFrameMetadata();
+	}
+
+	public static EnderCrystalMetadata newEnderCrystalMetadata() {
+		return new EnderCrystalMetadata();
 	}
 
 	/**
@@ -121,7 +253,7 @@ public class EntityMetadata {
 	 * Represents the Metadata of a Living Entity
 	 *
 	 */
-	public static class LivingEntityMetadata extends EntityMetadata {
+	protected static class LivingEntityMetadata extends EntityMetadata {
 		/**
 		 * Index: 6
 		 * Type: Living Entity
@@ -238,7 +370,7 @@ public class EntityMetadata {
 	 * Ageable - can be a child or adult
 	 *
 	 */
-	public static class AgeableMetadata extends LivingEntityMetadata {
+	protected static class AgeableMetadata extends LivingEntityMetadata {
 		/**
 		 * Index: 12
 		 * Type: Ageable
@@ -258,7 +390,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class HorseMetadata extends AgeableMetadata {
+	protected static class HorseMetadata extends AgeableMetadata {
 		public void setHorseFlags(int flags) {
 			setMeta(16, flags);
 		}
@@ -325,7 +457,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class BatMetadata extends LivingEntityMetadata {
+	protected static class BatMetadata extends LivingEntityMetadata {
 		public void setBatHanging(byte hanging) {
 			setMeta(16, hanging);
 		}
@@ -335,7 +467,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class TameableMetadata extends AgeableMetadata {
+	protected static class TameableMetadata extends AgeableMetadata {
 
 		public void setTame(byte tame) {
 			setMeta(16, tame);
@@ -354,7 +486,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class OcelotMetadata extends TameableMetadata {
+	protected static class OcelotMetadata extends TameableMetadata {
 		public void setOcelotType(byte type) {
 			setMeta(18, type);
 		}
@@ -365,7 +497,7 @@ public class EntityMetadata {
 
 	}
 
-	public static class WolfMetadata extends TameableMetadata {
+	protected static class WolfMetadata extends TameableMetadata {
 		public void setWolfFlags(byte flags) {
 			setMeta(16, flags);
 		}
@@ -399,7 +531,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class PigMetadata extends AgeableMetadata {
+	protected static class PigMetadata extends AgeableMetadata {
 		public void setHasSaddle(byte value) {
 			setMeta(16, value);
 		}
@@ -409,7 +541,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class SheepMetadata extends AgeableMetadata {
+	protected static class SheepMetadata extends AgeableMetadata {
 		public void setSheepFlags(byte flags) {
 			setMeta(16, flags);
 		}
@@ -419,7 +551,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class VilagerMetadata extends AgeableMetadata {
+	protected static class VillagerMetadata extends AgeableMetadata {
 
 		public void setVillagerType(byte type) {
 			setMeta(16, type);
@@ -430,7 +562,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class EndermanMetadata extends LivingEntityMetadata {
+	protected static class EndermanMetadata extends LivingEntityMetadata {
 
 		public void setEndermanBlock(byte block) {
 			setMeta(16, block);
@@ -458,7 +590,7 @@ public class EntityMetadata {
 
 	}
 
-	public static class ZombieMetadata extends LivingEntityMetadata {
+	protected static class ZombieMetadata extends LivingEntityMetadata {
 
 		public void setZombieChid(byte child) {
 			setMeta(12, child);
@@ -485,10 +617,10 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class PigZombieMetadata extends ZombieMetadata {
+	protected static class PigZombieMetadata extends ZombieMetadata {
 	}
 
-	public static class BlazeMetadata extends LivingEntityMetadata {
+	protected static class BlazeMetadata extends LivingEntityMetadata {
 
 		public void setBlazeOnFire(byte onFire) {
 			setMeta(16, onFire);
@@ -499,7 +631,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class SpiderMetadata extends LivingEntityMetadata {
+	protected static class SpiderMetadata extends LivingEntityMetadata {
 
 		public void setSpiderClimbing(byte climbing) {
 			setMeta(16, climbing);
@@ -510,10 +642,10 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class CaveSpiderMetadata extends SpiderMetadata {
+	protected static class CaveSpiderMetadata extends SpiderMetadata {
 	}
 
-	public static class CreeperMetadata extends LivingEntityMetadata {
+	protected static class CreeperMetadata extends LivingEntityMetadata {
 		public void setCreeperState(byte flags) {
 			setMeta(16, flags);
 		}
@@ -531,7 +663,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class GhastMetadata extends LivingEntityMetadata {
+	protected static class GhastMetadata extends LivingEntityMetadata {
 
 		public void setGhastAttacking(byte attacking) {
 			setMeta(17, attacking);
@@ -542,7 +674,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class SlimeMetadata extends LivingEntityMetadata {
+	protected static class SlimeMetadata extends LivingEntityMetadata {
 		public void setSlimeSlze(byte size) {
 			setMeta(16, size);
 		}
@@ -553,11 +685,11 @@ public class EntityMetadata {
 
 	}
 
-	public static class MagmaCubeMetadata extends SlimeMetadata {
+	protected static class MagmaCubeMetadata extends SlimeMetadata {
 
 	}
 
-	public static class SkeletonMetadata extends LivingEntityMetadata {
+	protected static class SkeletonMetadata extends LivingEntityMetadata {
 		public void setSkeletonType(byte type) {
 			setMeta(13, type);
 		}
@@ -567,7 +699,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class WitchMetadata extends LivingEntityMetadata {
+	protected static class WitchMetadata extends LivingEntityMetadata {
 
 		public void setWitchAgro(byte agro) {
 			setMeta(21, agro);
@@ -578,7 +710,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class IronGolemMetadata extends LivingEntityMetadata {
+	protected static class IronGolemMetadata extends LivingEntityMetadata {
 		public void setIronGolemPlayerCreated(byte value) {
 			setMeta(16, value);
 		}
@@ -588,7 +720,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class WitherMetadata extends LivingEntityMetadata {
+	protected static class WitherMetadata extends LivingEntityMetadata {
 		public void setWitherHeadTarget1(int target) {
 			setMeta(17, target);
 		}
@@ -622,7 +754,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class BoatMetadata extends EntityMetadata {
+	protected static class BoatMetadata extends EntityMetadata {
 		public void setBoatTimeSinceHit(int time) {
 			setMeta(17, time);
 		}
@@ -648,7 +780,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class MinecartMetadata extends EntityMetadata {
+	protected static class MinecartMetadata extends EntityMetadata {
 		public void setMinecraftShakingPower(int power) {
 			setMeta(17, power);
 		}
@@ -699,7 +831,7 @@ public class EntityMetadata {
 
 	}
 
-	public static class FurnaceMinecartMetadata extends MinecartMetadata {
+	protected static class FurnaceMinecartMetadata extends MinecartMetadata {
 
 		public void setFurnaceMinecartPowered(byte powered) {
 			setMeta(16, powered);
@@ -710,7 +842,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class ItemMetadata extends EntityMetadata {
+	protected static class ItemMetadata extends EntityMetadata {
 		public void setItem(ItemStack item) {
 			setMeta(10, item);
 		}
@@ -720,7 +852,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class ArrowMetadata extends EntityMetadata {
+	protected static class ArrowMetadata extends EntityMetadata {
 		public void setArrowCriticalHit(byte value) {
 			setMeta(16, value);
 		}
@@ -733,7 +865,7 @@ public class EntityMetadata {
 	/**
 	 * ProtocolLib does not yet support this function
 	 */
-	public static class FireworkMetadata extends EntityMetadata {
+	protected static class FireworkMetadata extends EntityMetadata {
 		public void setFireworkInfo() {
 		}
 
@@ -745,7 +877,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class ItemFrameMetadata extends EntityMetadata {
+	protected static class ItemFrameMetadata extends EntityMetadata {
 		public void setItemFrameItem(ItemStack item) {
 			setMeta(2, item);
 		}
@@ -763,7 +895,7 @@ public class EntityMetadata {
 		}
 	}
 
-	public static class EnderCrystalMetadata extends EntityMetadata {
+	protected static class EnderCrystalMetadata extends EntityMetadata {
 		public void setEnderCrystalAlive(byte health) {
 			setMeta(8, health);
 		}
@@ -779,5 +911,13 @@ public class EntityMetadata {
 
 	protected Object getMeta(int index) {
 		return metadata.getObject(index);
+	}
+
+	protected boolean getFlag(int index, int mask) {
+		return ((Integer) getMeta(index) & mask) != 0;
+	}
+
+	protected void setFlag(int index, int mask, boolean value) {
+		setMeta(index, ((Integer) getMeta(index) & ~mask) | (value ? mask : 0));
 	}
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -120,7 +120,7 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setWolfFlags(byte flags) {
-		this.setObject(18, flags);
+		this.setObject(16, flags);
 	}
 
 	public void setWolfHealth(float health) {
@@ -128,31 +128,31 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setWolfBegging(byte begging) {
-		this.setObject(18, begging);
+		this.setObject(19, begging);
 	}
 
 	public void setWolfCollarColor(byte color) {
-		this.setObject(18, color);
+		this.setObject(20, color);
 	}
 
 	public void setHasSaddle(byte value) {
-		this.setObject(18, value);
+		this.setObject(16, value);
 	}
 
 	public void setSheepFlags(byte flags) {
-		this.setObject(18, flags);
+		this.setObject(16, flags);
 	}
 
 	public void setVillagerType(byte type) {
-		this.setObject(18, type);
+		this.setObject(16, type);
 	}
 
 	public void setEndermanBlock(byte block) {
-		this.setObject(18, block);
+		this.setObject(16, block);
 	}
 
 	public void setEndermanBlockData(byte blockData) {
-		this.setObject(18, blockData);
+		this.setObject(17, blockData);
 	}
 
 	public void setEndermanScreaming(byte value) {
@@ -160,59 +160,59 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setZombieChid(byte child) {
-		this.setObject(18, child);
+		this.setObject(12, child);
 	}
 
 	public void setZombieVillager(byte villager) {
-		this.setObject(18, villager);
+		this.setObject(13, villager);
 	}
 
 	public void setZombieConverting(byte converting) {
-		this.setObject(18, converting);
+		this.setObject(14, converting);
 	}
 
 	public void setBlazeOnFire(byte onFire) {
-		this.setObject(18, onFire);
+		this.setObject(16, onFire);
 	}
 
 	public void setSpiderClimbing(byte climbing) {
-		this.setObject(18, climbing);
+		this.setObject(16, climbing);
 	}
 
 	public void setCreeperState(byte flags) {
-		this.setObject(18, flags);
+		this.setObject(16, flags);
 	}
 
 	public void setCreeperCharged(byte charged) {
-		this.setObject(18, charged);
+		this.setObject(17, charged);
 	}
 
 	public void setGhastAttacking(byte attacking) {
-		this.setObject(18, attacking);
+		this.setObject(17, attacking);
 	}
 
 	public void setSlimeSlze(byte size) {
-		this.setObject(18, size);
+		this.setObject(16, size);
 	}
 
 	public void setMagmaCubeSize(byte size) {
-		this.setObject(18, size);
+		this.setObject(16, size);
 	}
 
 	public void setSkeletonType(byte type) {
-		this.setObject(18, type);
+		this.setObject(13, type);
 	}
 
 	public void setWitchAgro(byte agro) {
-		this.setObject(18, agro);
+		this.setObject(21, agro);
 	}
 
 	public void setIronGolemPlayerCreated(byte value) {
-		this.setObject(18, value);
+		this.setObject(16, value);
 	}
 
 	public void setWitherHeadTarget1(int target) {
-		this.setObject(18, target);
+		this.setObject(17, target);
 	}
 
 	public void setWitherHeadTarget2(int target) {
@@ -220,15 +220,15 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setWitherHeadTarget3(int target) {
-		this.setObject(18, target);
+		this.setObject(19, target);
 	}
 
 	public void setWitherInvulnerableTime(int time) {
-		this.setObject(18, time);
+		this.setObject(20, time);
 	}
 
 	public void setBoatTimeSinceHit(int time) {
-		this.setObject(18, time);
+		this.setObject(17, time);
 	}
 
 	public void setBoatFowardDirection(int dir) {
@@ -236,11 +236,11 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setBoatDamage(int damage) {
-		this.setObject(18, damage);
+		this.setObject(19, damage);
 	}
 
 	public void setMinecraftShakingPower(int power) {
-		this.setObject(18, power);
+		this.setObject(17, power);
 	}
 
 	public void setMinecartSkakeingDirection(int dir) {
@@ -248,23 +248,23 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setMinecartDamage(float damage) {
-		this.setObject(18, damage);
+		this.setObject(19, damage);
 	}
 
 	public void setBlockInMinecart(int block) {
-		this.setObject(18, block);
+		this.setObject(20, block);
 	}
 
 	public void setMinecraftBlockYOffest(int y) {
-		this.setObject(18, y);
+		this.setObject(21, y);
 	}
-	
-	public void setShowMinecartBlock(byte value){
-		this.setObject(18, value);
+
+	public void setShowMinecartBlock(byte value) {
+		this.setObject(22, value);
 	}
 
 	public void setFurnaceMinecartPowered(byte powered) {
-		this.setObject(18, powered);
+		this.setObject(16, powered);
 	}
 
 	/**
@@ -274,7 +274,7 @@ public class EntityMetadata extends WrappedDataWatcher {
 	}
 
 	public void setArrowCriticalHit(byte value) {
-		this.setObject(18, value);
+		this.setObject(16, value);
 	}
 
 	/**
@@ -282,19 +282,267 @@ public class EntityMetadata extends WrappedDataWatcher {
 	 */
 	public void setFireworkInfo() {
 	}
-	
+
 	/**
 	 * ProtocolLib does not yet support this function
 	 */
 	public void setItemFrameItem() {
 	}
 
-	public void setItemFrameRotation() {
-		this.setObject(18, type);
+	public void setItemFrameRotation(byte rotation) {
+		this.setObject(3, rotation);
 	}
 
-	public void setEnderCrystalAlive() {
-		this.setObject(18, type);
+	public void setEnderCrystalAlive(byte health) {
+		this.setObject(8, health);
 	}
 
+	public Object getFlags() {
+		return this.getObject(0);
+	}
+
+	public Object getAir() {
+		return this.getObject(1);
+	}
+
+	public Object getHealth() {
+		return this.getObject(6);
+	}
+
+	public Object getPotionEffectColor() {
+		return this.getObject(7);
+	}
+
+	public Object getPotionEffectAmbient() {
+		return this.getObject(8);
+	}
+
+	public Object getNumArrowsInEntity() {
+		return this.getObject(9);
+	}
+
+	public Object getNameTag() {
+		return this.getObject(10);
+	}
+
+	public Object getAlwaysShowNameTag() {
+		return this.getObject(11);
+	}
+
+	public Object getEntityAge() {
+		return this.getObject(12);
+	}
+
+	public Object getHorseFlags() {
+		return this.getObject(16);
+	}
+
+	public Object getHorgetype() {
+		return this.getObject(19);
+	}
+
+	public Object getHorseColorAndTexture() {
+		return this.getObject(20);
+	}
+
+	public Object getHorseOwnerName() {
+		return this.getObject(21);
+	}
+
+	public Object getBatHanging() {
+		return this.getObject(16);
+	}
+
+	public Object getTame() {
+		return this.getObject(16);
+	}
+
+	public Object getOwnersName() {
+		return this.getObject(17);
+	}
+
+	public Object getOcelotType() {
+		return this.getObject(18);
+	}
+
+	public Object getWolfFlags() {
+		return this.getObject(16);
+	}
+
+	public Object getWolfHealth() {
+		return this.getObject(18);
+	}
+
+	public Object getWolfBegging() {
+		return this.getObject(19);
+	}
+
+	public Object getWolfCollarColor() {
+		return this.getObject(20);
+	}
+
+	public Object getHasSaddle() {
+		return this.getObject(16);
+	}
+
+	public Object getSheepFlags() {
+		return this.getObject(16);
+	}
+
+	public Object getVillagerType() {
+		return this.getObject(16);
+	}
+
+	public Object getEndermanBlock() {
+		return this.getObject(16);
+	}
+
+	public Object getEndermanBlockData() {
+		return this.getObject(17);
+	}
+
+	public Object getEndermanScreaming() {
+		return this.getObject(18);
+	}
+
+	public Object getZombieChid() {
+		return this.getObject(12);
+	}
+
+	public Object getZombieVillager() {
+		return this.getObject(13);
+	}
+
+	public Object getZombieConverting() {
+		return this.getObject(14);
+	}
+
+	public Object getBlazeOnFire() {
+		return this.getObject(16);
+	}
+
+	public Object getSpiderClimbing() {
+		return this.getObject(16);
+	}
+
+	public Object getCreeperState() {
+		return this.getObject(16);
+	}
+
+	public Object getCreeperCharged() {
+		return this.getObject(17);
+	}
+
+	public Object getGhastAttacking() {
+		return this.getObject(16);
+	}
+
+	public Object getSlimeSlze() {
+		return this.getObject(16);
+	}
+
+	public Object getMagmaCubeSize() {
+		return this.getObject(16);
+	}
+
+	public Object getSkeletonType() {
+		return this.getObject(13);
+	}
+
+	public Object getWitchAgro() {
+		return this.getObject(21);
+	}
+
+	public Object getIronGolemPlayerCreated() {
+		return this.getObject(16);
+	}
+
+	public Object getWitherHeadTarget1() {
+		return this.getObject(17);
+	}
+
+	public Object getWitherHeadTarget2() {
+		return this.getObject(18);
+	}
+
+	public Object getWitherHeadTarget3() {
+		return this.getObject(19);
+	}
+
+	public Object getWitherInvulnerableTime() {
+		return this.getObject(20);
+	}
+
+	public Object getBoatTimeSinceHit() {
+		return this.getObject(17);
+	}
+
+	public Object getBoatFowardDirection() {
+		return this.getObject(18);
+	}
+
+	public Object getBoatDamage() {
+		return this.getObject(19);
+	}
+
+	public Object getMinecraftShakingPower() {
+		return this.getObject(17);
+	}
+
+	public Object getMinecartSkakeingDirection() {
+		return this.getObject(18);
+	}
+
+	public Object getMinecartDamage() {
+		return this.getObject(19);
+	}
+
+	public Object getBlockInMinecart() {
+		return this.getObject(20);
+	}
+
+	public Object getMinecraftBlockYOffest() {
+		return this.getObject(21);
+	}
+
+	public Object getShowMinecartBlock() {
+		return this.getObject(22);
+	}
+
+	public Object getFurnaceMinecartPowered() {
+		return this.getObject(16);
+	}
+
+	/**
+	 * ProtocolLib does not yet support return this function
+	 */
+	public Object getItem() {
+		return null;
+	}
+
+	public Object getArrowCriticalHit(byte value) {
+		return this.getObject(16);
+	}
+
+	/**
+	 * ProtocolLib does not yet support return this function
+	 */
+	public Object getFireworkInfo() {
+		return null;
+	}
+
+	/**
+	 * ProtocolLib does not yet support return this function
+	 */
+	public Object getItemFrameItem() {
+		return null;
+	}
+
+	public Object getItemFrameRotation(byte rotation) {
+		return this.getObject(3);
+	}
+
+	public Object getEnderCrystalAlive(byte health) {
+		return this.getObject(8);
+	}
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/EntityMetadata.java
@@ -1,6 +1,7 @@
 package com.comphenix.packetwrapper;
 
 import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
 
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 
@@ -14,7 +15,14 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher;
  * 
  * @author Quantum64
  */
-public class EntityMetadata extends WrappedDataWatcher {
+
+public class EntityMetadata {
+
+	private WrappedDataWatcher metadata;
+
+	public WrappedDataWatcher getMetadata() {
+		return metadata;
+	}
 
 	/**
 	 * Index: 0
@@ -28,7 +36,7 @@ public class EntityMetadata extends WrappedDataWatcher {
 	 * 0x20	 Invisible
 	 */
 	public void setFlags(byte flags) {
-		this.setObject(0, flags);
+		setMeta(0, flags);
 	}
 
 	/**
@@ -38,511 +46,583 @@ public class EntityMetadata extends WrappedDataWatcher {
 	 * @param air - Current time in air
 	 */
 	public void setAir(short air) {
-		this.setObject(1, air);
-	}
-
-	/**
-	 * Index: 6
-	 * Type: Living Entity
-	 * Use: Sets the living Entity's health
-	 * @param health - health of mob as a float
-	 */
-	public void setHealth(float health) {
-		this.setObject(6, health);
-	}
-
-	/**
-	 * Index: 7
-	 * Type: Living Entity
-	 * Use: Set the potion effect color for the Living Entity
-	 * @param color -  color of potion effect particals
-	 */
-	public void setPotionEffectColor(int color) {
-		this.setObject(7, color);
-	}
-
-	/**
-	 * Index: 8
-	 * Type: Living Entity
-	 * Use: Sets if the potion effect particals are visible or not
-	 * @param value - byte 1 or 0 (see potion effect particals = 1, no potion effect particals = 0)
-	 */
-	public void setPotionEffectAmbient(byte value) {
-		this.setObject(8, value);
-	}
-
-	public void setNumArrowsInEntity(byte arrows) {
-		this.setObject(9, arrows);
-	}
-
-	public void setNameTag(String nameTag) {
-		this.setObject(10, ChatColor.translateAlternateColorCodes('&', nameTag));
-	}
-
-	public void setAlwaysShowNameTag(byte value) {
-		this.setObject(11, value);
-	}
-
-	public void setEntityAge(int age) {
-		this.setObject(12, age);
-	}
-
-	public void setHorseFlags(int flags) {
-		this.setObject(16, flags);
-	}
-
-	public void setHorseType(byte type) {
-		this.setObject(19, type);
-	}
-
-	public void setHorseColorAndTexture(int value) {
-		this.setObject(20, value);
-	}
-
-	public void setHorseOwnerName(String name) {
-		this.setObject(21, name);
-	}
-
-	public void setBatHanging(byte hanging) {
-		this.setObject(16, hanging);
-	}
-
-	public void setTame(byte tame) {
-		this.setObject(16, tame);
-	}
-
-	public void setOwnersName(String name) {
-		this.setObject(17, name);
-	}
-
-	public void setOcelotType(byte type) {
-		this.setObject(18, type);
-	}
-
-	public void setWolfFlags(byte flags) {
-		this.setObject(16, flags);
-	}
-
-	public void setWolfHealth(float health) {
-		this.setObject(18, health);
-	}
-
-	public void setWolfBegging(byte begging) {
-		this.setObject(19, begging);
-	}
-
-	public void setWolfCollarColor(byte color) {
-		this.setObject(20, color);
-	}
-
-	public void setHasSaddle(byte value) {
-		this.setObject(16, value);
-	}
-
-	public void setSheepFlags(byte flags) {
-		this.setObject(16, flags);
-	}
-
-	public void setVillagerType(byte type) {
-		this.setObject(16, type);
-	}
-
-	public void setEndermanBlock(byte block) {
-		this.setObject(16, block);
-	}
-
-	public void setEndermanBlockData(byte blockData) {
-		this.setObject(17, blockData);
-	}
-
-	public void setEndermanScreaming(byte value) {
-		this.setObject(18, value);
-	}
-
-	public void setZombieChid(byte child) {
-		this.setObject(12, child);
-	}
-
-	public void setZombieVillager(byte villager) {
-		this.setObject(13, villager);
-	}
-
-	public void setZombieConverting(byte converting) {
-		this.setObject(14, converting);
-	}
-
-	public void setBlazeOnFire(byte onFire) {
-		this.setObject(16, onFire);
-	}
-
-	public void setSpiderClimbing(byte climbing) {
-		this.setObject(16, climbing);
-	}
-
-	public void setCreeperState(byte flags) {
-		this.setObject(16, flags);
-	}
-
-	public void setCreeperCharged(byte charged) {
-		this.setObject(17, charged);
-	}
-
-	public void setGhastAttacking(byte attacking) {
-		this.setObject(17, attacking);
-	}
-
-	public void setSlimeSlze(byte size) {
-		this.setObject(16, size);
-	}
-
-	public void setMagmaCubeSize(byte size) {
-		this.setObject(16, size);
-	}
-
-	public void setSkeletonType(byte type) {
-		this.setObject(13, type);
-	}
-
-	public void setWitchAgro(byte agro) {
-		this.setObject(21, agro);
-	}
-
-	public void setIronGolemPlayerCreated(byte value) {
-		this.setObject(16, value);
-	}
-
-	public void setWitherHeadTarget1(int target) {
-		this.setObject(17, target);
-	}
-
-	public void setWitherHeadTarget2(int target) {
-		this.setObject(18, target);
-	}
-
-	public void setWitherHeadTarget3(int target) {
-		this.setObject(19, target);
-	}
-
-	public void setWitherInvulnerableTime(int time) {
-		this.setObject(20, time);
-	}
-
-	public void setBoatTimeSinceHit(int time) {
-		this.setObject(17, time);
-	}
-
-	public void setBoatFowardDirection(int dir) {
-		this.setObject(18, dir);
-	}
-
-	public void setBoatDamage(int damage) {
-		this.setObject(19, damage);
-	}
-
-	public void setMinecraftShakingPower(int power) {
-		this.setObject(17, power);
-	}
-
-	public void setMinecartSkakeingDirection(int dir) {
-		this.setObject(18, dir);
-	}
-
-	public void setMinecartDamage(float damage) {
-		this.setObject(19, damage);
-	}
-
-	public void setBlockInMinecart(int block) {
-		this.setObject(20, block);
-	}
-
-	public void setMinecraftBlockYOffest(int y) {
-		this.setObject(21, y);
-	}
-
-	public void setShowMinecartBlock(byte value) {
-		this.setObject(22, value);
-	}
-
-	public void setFurnaceMinecartPowered(byte powered) {
-		this.setObject(16, powered);
-	}
-
-	/**
-	 * ProtocolLib does not yet support this function
-	 */
-	public void setItem() {
-	}
-
-	public void setArrowCriticalHit(byte value) {
-		this.setObject(16, value);
-	}
-
-	/**
-	 * ProtocolLib does not yet support this function
-	 */
-	public void setFireworkInfo() {
-	}
-
-	/**
-	 * ProtocolLib does not yet support this function
-	 */
-	public void setItemFrameItem() {
-	}
-
-	public void setItemFrameRotation(byte rotation) {
-		this.setObject(3, rotation);
-	}
-
-	public void setEnderCrystalAlive(byte health) {
-		this.setObject(8, health);
+		setMeta(1, air);
 	}
 
 	public Object getFlags() {
-		return this.getObject(0);
+		return getMeta(0);
 	}
 
 	public Object getAir() {
-		return this.getObject(1);
+		return getMeta(1);
 	}
 
-	public Object getHealth() {
-		return this.getObject(6);
+	public static class LivingEntityMetadata extends EntityMetadata {
+		/**
+		 * Index: 6
+		 * Type: Living Entity
+		 * Use: Sets the living Entity's health
+		 * @param health - health of mob as a float
+		 */
+		public void setHealth(float health) {
+			setMeta(6, health);
+		}
+
+		/**
+		 * Index: 7
+		 * Type: Living Entity
+		 * Use: Set the potion effect color for the Living Entity
+		 * @param color -  color of potion effect particals
+		 */
+		public void setPotionEffectColor(int color) {
+			setMeta(7, color);
+		}
+
+		/**
+		 * Index: 8
+		 * Type: Living Entity
+		 * Use: Sets if the potion effect particals are visible or not
+		 * @param value - byte 1 or 0 (see potion effect particals = 1, no potion effect particals = 0)
+		 */
+		public void setPotionEffectAmbient(byte value) {
+			setMeta(8, value);
+		}
+
+		public void setNumArrowsInEntity(byte arrows) {
+			setMeta(9, arrows);
+		}
+
+		public void setNameTag(String nameTag) {
+			setMeta(10, ChatColor.translateAlternateColorCodes('&', nameTag));
+		}
+
+		public void setAlwaysShowNameTag(byte value) {
+			setMeta(11, value);
+		}
+
+		public Object getHealth() {
+			return getMeta(6);
+		}
+
+		public Object getPotionEffectColor() {
+			return getMeta(7);
+		}
+
+		public Object getPotionEffectAmbient() {
+			return getMeta(8);
+		}
+
+		public Object getNumArrowsInEntity() {
+			return getMeta(9);
+		}
+
+		public Object getNameTag() {
+			return getMeta(10);
+		}
+
+		public Object getAlwaysShowNameTag() {
+			return getMeta(11);
+		}
+
 	}
 
-	public Object getPotionEffectColor() {
-		return this.getObject(7);
+	public static class AgeableMetadata extends LivingEntityMetadata {
+		public void setEntityAge(int age) {
+			setMeta(12, age);
+		}
+
+		public Object getEntityAge() {
+			return getMeta(12);
+		}
 	}
 
-	public Object getPotionEffectAmbient() {
-		return this.getObject(8);
+	public static class HorseMetadata extends AgeableMetadata {
+		public void setHorseFlags(int flags) {
+			setMeta(16, flags);
+		}
+
+		public void setHorseType(byte type) {
+			setMeta(19, type);
+		}
+
+		public void setHorseColorAndTexture(int value) {
+			setMeta(20, value);
+		}
+
+		public void setHorseOwnerName(String name) {
+			setMeta(21, name);
+		}
+
+		public Object getHorseFlags() {
+			return getMeta(16);
+		}
+
+		public Object getHorgetype() {
+			return getMeta(19);
+		}
+
+		public Object getHorseColorAndTexture() {
+			return getMeta(20);
+		}
+
+		public Object getHorseOwnerName() {
+			return getMeta(21);
+		}
 	}
 
-	public Object getNumArrowsInEntity() {
-		return this.getObject(9);
+	public static class BatMetadata extends LivingEntityMetadata {
+		public void setBatHanging(byte hanging) {
+			setMeta(16, hanging);
+		}
+
+		public Object getBatHanging() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getNameTag() {
-		return this.getObject(10);
+	public static class TameableMetadata extends AgeableMetadata {
+
+		public void setTame(byte tame) {
+			setMeta(16, tame);
+		}
+
+		public void setOwnersName(String name) {
+			setMeta(17, name);
+		}
+
+		public Object getTame() {
+			return getMeta(16);
+		}
+
+		public Object getOwnersName() {
+			return getMeta(17);
+		}
 	}
 
-	public Object getAlwaysShowNameTag() {
-		return this.getObject(11);
+	public static class OcelotMetadata extends TameableMetadata {
+		public void setOcelotType(byte type) {
+			setMeta(18, type);
+		}
+
+		public Object getOcelotType() {
+			return getMeta(18);
+		}
+
 	}
 
-	public Object getEntityAge() {
-		return this.getObject(12);
+	public static class WolfMetadata extends TameableMetadata {
+		public void setWolfFlags(byte flags) {
+			setMeta(16, flags);
+		}
+
+		public void setWolfHealth(float health) {
+			setMeta(18, health);
+		}
+
+		public void setWolfBegging(byte begging) {
+			setMeta(19, begging);
+		}
+
+		public void setWolfCollarColor(byte color) {
+			setMeta(20, color);
+		}
+
+		public Object getWolfFlags() {
+			return getMeta(16);
+		}
+
+		public Object getWolfHealth() {
+			return getMeta(18);
+		}
+
+		public Object getWolfBegging() {
+			return getMeta(19);
+		}
+
+		public Object getWolfCollarColor() {
+			return getMeta(20);
+		}
 	}
 
-	public Object getHorseFlags() {
-		return this.getObject(16);
+	public static class PigMetadata extends AgeableMetadata {
+		public void setHasSaddle(byte value) {
+			setMeta(16, value);
+		}
+
+		public Object getHasSaddle() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getHorgetype() {
-		return this.getObject(19);
+	public static class SheepMetadata extends AgeableMetadata {
+		public void setSheepFlags(byte flags) {
+			setMeta(16, flags);
+		}
+
+		public Object getSheepFlags() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getHorseColorAndTexture() {
-		return this.getObject(20);
+	public static class VilagerMetadata extends AgeableMetadata {
+
+		public void setVillagerType(byte type) {
+			setMeta(16, type);
+		}
+
+		public Object getVillagerType() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getHorseOwnerName() {
-		return this.getObject(21);
+	public static class EndermanMetadata extends LivingEntityMetadata {
+
+		public void setEndermanBlock(byte block) {
+			setMeta(16, block);
+		}
+
+		public void setEndermanBlockData(byte blockData) {
+			setMeta(17, blockData);
+		}
+
+		public void setEndermanScreaming(byte value) {
+			setMeta(18, value);
+		}
+
+		public Object getEndermanBlock() {
+			return getMeta(16);
+		}
+
+		public Object getEndermanBlockData() {
+			return getMeta(17);
+		}
+
+		public Object getEndermanScreaming() {
+			return getMeta(18);
+		}
+
 	}
 
-	public Object getBatHanging() {
-		return this.getObject(16);
+	public static class ZombieMetadata extends LivingEntityMetadata {
+
+		public void setZombieChid(byte child) {
+			setMeta(12, child);
+		}
+
+		public void setZombieVillager(byte villager) {
+			setMeta(13, villager);
+		}
+
+		public void setZombieConverting(byte converting) {
+			setMeta(14, converting);
+		}
+
+		public Object getZombieChid() {
+			return getMeta(12);
+		}
+
+		public Object getZombieVillager() {
+			return getMeta(13);
+		}
+
+		public Object getZombieConverting() {
+			return getMeta(14);
+		}
 	}
 
-	public Object getTame() {
-		return this.getObject(16);
+	public static class PigZombieMetadata extends ZombieMetadata {
 	}
 
-	public Object getOwnersName() {
-		return this.getObject(17);
+	public static class BlazeMetadata extends LivingEntityMetadata {
+
+		public void setBlazeOnFire(byte onFire) {
+			setMeta(16, onFire);
+		}
+
+		public Object getBlazeOnFire() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getOcelotType() {
-		return this.getObject(18);
+	public static class SpiderMetadata extends LivingEntityMetadata {
+
+		public void setSpiderClimbing(byte climbing) {
+			setMeta(16, climbing);
+		}
+
+		public Object getSpiderClimbing() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getWolfFlags() {
-		return this.getObject(16);
+	public static class CaveSpiderMetadata extends SpiderMetadata {
 	}
 
-	public Object getWolfHealth() {
-		return this.getObject(18);
+	public static class CreeperMetadata extends LivingEntityMetadata {
+		public void setCreeperState(byte flags) {
+			setMeta(16, flags);
+		}
+
+		public void setCreeperCharged(byte charged) {
+			setMeta(17, charged);
+		}
+
+		public Object getCreeperState() {
+			return getMeta(16);
+		}
+
+		public Object getCreeperCharged() {
+			return getMeta(17);
+		}
 	}
 
-	public Object getWolfBegging() {
-		return this.getObject(19);
+	public static class GhastMetadata extends LivingEntityMetadata {
+
+		public void setGhastAttacking(byte attacking) {
+			setMeta(17, attacking);
+		}
+
+		public Object getGhastAttacking() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getWolfCollarColor() {
-		return this.getObject(20);
+	public static class SlimeMetadata extends LivingEntityMetadata {
+		public void setSlimeSlze(byte size) {
+			setMeta(16, size);
+		}
+
+		public Object getSlimeSlze() {
+			return getMeta(16);
+		}
+
 	}
 
-	public Object getHasSaddle() {
-		return this.getObject(16);
+	public static class MagmaCubeMetadata extends SlimeMetadata {
+
 	}
 
-	public Object getSheepFlags() {
-		return this.getObject(16);
+	public static class SkeletonMetadata extends LivingEntityMetadata {
+		public void setSkeletonType(byte type) {
+			setMeta(13, type);
+		}
+
+		public Object getSkeletonType() {
+			return getMeta(13);
+		}
 	}
 
-	public Object getVillagerType() {
-		return this.getObject(16);
+	public static class WitchMetadata extends LivingEntityMetadata {
+
+		public void setWitchAgro(byte agro) {
+			setMeta(21, agro);
+		}
+
+		public Object getWitchAgro() {
+			return getMeta(21);
+		}
 	}
 
-	public Object getEndermanBlock() {
-		return this.getObject(16);
+	public static class IronGolemMetadata extends LivingEntityMetadata {
+		public void setIronGolemPlayerCreated(byte value) {
+			setMeta(16, value);
+		}
+
+		public Object getIronGolemPlayerCreated() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getEndermanBlockData() {
-		return this.getObject(17);
+	public static class WitherMetadata extends LivingEntityMetadata {
+		public void setWitherHeadTarget1(int target) {
+			setMeta(17, target);
+		}
+
+		public void setWitherHeadTarget2(int target) {
+			setMeta(18, target);
+		}
+
+		public void setWitherHeadTarget3(int target) {
+			setMeta(19, target);
+		}
+
+		public void setWitherInvulnerableTime(int time) {
+			setMeta(20, time);
+		}
+
+		public Object getWitherHeadTarget1() {
+			return getMeta(17);
+		}
+
+		public Object getWitherHeadTarget2() {
+			return getMeta(18);
+		}
+
+		public Object getWitherHeadTarget3() {
+			return getMeta(19);
+		}
+
+		public Object getWitherInvulnerableTime() {
+			return getMeta(20);
+		}
 	}
 
-	public Object getEndermanScreaming() {
-		return this.getObject(18);
+	public static class BoatMetadata extends EntityMetadata {
+		public void setBoatTimeSinceHit(int time) {
+			setMeta(17, time);
+		}
+
+		public void setBoatFowardDirection(int dir) {
+			setMeta(18, dir);
+		}
+
+		public void setBoatDamage(int damage) {
+			setMeta(19, damage);
+		}
+
+		public Object getBoatTimeSinceHit() {
+			return getMeta(17);
+		}
+
+		public Object getBoatFowardDirection() {
+			return getMeta(18);
+		}
+
+		public Object getBoatDamage() {
+			return getMeta(19);
+		}
 	}
 
-	public Object getZombieChid() {
-		return this.getObject(12);
+	public static class MinecartMetadata extends EntityMetadata {
+		public void setMinecraftShakingPower(int power) {
+			setMeta(17, power);
+		}
+
+		public void setMinecartSkakeingDirection(int dir) {
+			setMeta(18, dir);
+		}
+
+		public void setMinecartDamage(float damage) {
+			setMeta(19, damage);
+		}
+
+		public void setBlockInMinecart(int block) {
+			setMeta(20, block);
+		}
+
+		public void setMinecraftBlockYOffest(int y) {
+			setMeta(21, y);
+		}
+
+		public void setShowMinecartBlock(byte value) {
+			setMeta(22, value);
+		}
+
+		public Object getMinecraftShakingPower() {
+			return getMeta(17);
+		}
+
+		public Object getMinecartSkakeingDirection() {
+			return getMeta(18);
+		}
+
+		public Object getMinecartDamage() {
+			return getMeta(19);
+		}
+
+		public Object getBlockInMinecart() {
+			return getMeta(20);
+		}
+
+		public Object getMinecraftBlockYOffest() {
+			return getMeta(21);
+		}
+
+		public Object getShowMinecartBlock() {
+			return getMeta(22);
+		}
+
 	}
 
-	public Object getZombieVillager() {
-		return this.getObject(13);
+	public static class FurnaceMinecartMetadata extends MinecartMetadata {
+
+		public void setFurnaceMinecartPowered(byte powered) {
+			setMeta(16, powered);
+		}
+
+		public Object getFurnaceMinecartPowered() {
+			return getMeta(16);
+		}
 	}
 
-	public Object getZombieConverting() {
-		return this.getObject(14);
+	public static class ItemMetadata extends EntityMetadata {
+		public void setItem(ItemStack item) {
+			setMeta(10, item);
+		}
+
+		public Object getItem() {
+			return getMeta(10);
+		}
 	}
 
-	public Object getBlazeOnFire() {
-		return this.getObject(16);
-	}
+	public static class ArrowMetadata extends EntityMetadata {
+		public void setArrowCriticalHit(byte value) {
+			setMeta(16, value);
+		}
 
-	public Object getSpiderClimbing() {
-		return this.getObject(16);
-	}
-
-	public Object getCreeperState() {
-		return this.getObject(16);
-	}
-
-	public Object getCreeperCharged() {
-		return this.getObject(17);
-	}
-
-	public Object getGhastAttacking() {
-		return this.getObject(16);
-	}
-
-	public Object getSlimeSlze() {
-		return this.getObject(16);
-	}
-
-	public Object getMagmaCubeSize() {
-		return this.getObject(16);
-	}
-
-	public Object getSkeletonType() {
-		return this.getObject(13);
-	}
-
-	public Object getWitchAgro() {
-		return this.getObject(21);
-	}
-
-	public Object getIronGolemPlayerCreated() {
-		return this.getObject(16);
-	}
-
-	public Object getWitherHeadTarget1() {
-		return this.getObject(17);
-	}
-
-	public Object getWitherHeadTarget2() {
-		return this.getObject(18);
-	}
-
-	public Object getWitherHeadTarget3() {
-		return this.getObject(19);
-	}
-
-	public Object getWitherInvulnerableTime() {
-		return this.getObject(20);
-	}
-
-	public Object getBoatTimeSinceHit() {
-		return this.getObject(17);
-	}
-
-	public Object getBoatFowardDirection() {
-		return this.getObject(18);
-	}
-
-	public Object getBoatDamage() {
-		return this.getObject(19);
-	}
-
-	public Object getMinecraftShakingPower() {
-		return this.getObject(17);
-	}
-
-	public Object getMinecartSkakeingDirection() {
-		return this.getObject(18);
-	}
-
-	public Object getMinecartDamage() {
-		return this.getObject(19);
-	}
-
-	public Object getBlockInMinecart() {
-		return this.getObject(20);
-	}
-
-	public Object getMinecraftBlockYOffest() {
-		return this.getObject(21);
-	}
-
-	public Object getShowMinecartBlock() {
-		return this.getObject(22);
-	}
-
-	public Object getFurnaceMinecartPowered() {
-		return this.getObject(16);
+		public Object getArrowCriticalHit(byte value) {
+			return getMeta(16);
+		}
 	}
 
 	/**
-	 * ProtocolLib does not yet support return this function
+	 * ProtocolLib does not yet support this function
 	 */
-	public Object getItem() {
-		return null;
+	public static class FireworkMetadata extends EntityMetadata {
+		public void setFireworkInfo() {
+		}
+
+		/**
+		 * ProtocolLib does not yet support return this function
+		 */
+		public Object getFireworkInfo() {
+			return null;
+		}
 	}
 
-	public Object getArrowCriticalHit(byte value) {
-		return this.getObject(16);
+	public static class ItemFrameMetadata extends EntityMetadata {
+		public void setItemFrameItem(ItemStack item) {
+			setMeta(2, item);
+		}
+
+		public void setItemFrameRotation(byte rotation) {
+			setMeta(3, rotation);
+		}
+
+		public Object getItemFrameItem() {
+			return getMeta(2);
+		}
+
+		public Object getItemFrameRotation(byte rotation) {
+			return getMeta(3);
+		}
 	}
 
-	/**
-	 * ProtocolLib does not yet support return this function
-	 */
-	public Object getFireworkInfo() {
-		return null;
+	public static class EnderCrystalMetadata extends EntityMetadata {
+		public void setEnderCrystalAlive(byte health) {
+			setMeta(8, health);
+		}
+
+		public Object getEnderCrystalAlive(byte health) {
+			return getMeta(8);
+		}
 	}
 
-	/**
-	 * ProtocolLib does not yet support return this function
-	 */
-	public Object getItemFrameItem() {
-		return null;
+	protected void setMeta(int index, Object o) {
+		metadata.setObject(index, o);
 	}
 
-	public Object getItemFrameRotation(byte rotation) {
-		return this.getObject(3);
-	}
-
-	public Object getEnderCrystalAlive(byte health) {
-		return this.getObject(8);
+	protected Object getMeta(int index) {
+		return metadata.getObject(index);
 	}
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet14SpawnNamedEntity.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet14SpawnNamedEntity.java
@@ -254,6 +254,14 @@ public class Packet14SpawnNamedEntity extends AbstractPacket {
     public void setMetadata(WrappedDataWatcher value) {
         handle.getDataWatcherModifier().write(0, value);
     }
+    
+    /**
+     * Set the data watcher.
+     * @param value - new value.
+    */
+    public void setMetadata(EntityMetadata value) {
+        handle.getDataWatcherModifier().write(0, value);
+    }
 }
 
 

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet14SpawnNamedEntity.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet14SpawnNamedEntity.java
@@ -255,13 +255,6 @@ public class Packet14SpawnNamedEntity extends AbstractPacket {
         handle.getDataWatcherModifier().write(0, value);
     }
     
-    /**
-     * Set the data watcher.
-     * @param value - new value.
-    */
-    public void setMetadata(EntityMetadata value) {
-        handle.getDataWatcherModifier().write(0, value);
-    }
 }
 
 

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet18SpawnMob.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet18SpawnMob.java
@@ -269,14 +269,7 @@ public class Packet18SpawnMob extends AbstractPacket {
     public void setMetadata(WrappedDataWatcher value) {
         handle.getDataWatcherModifier().write(0, value);
     }
-    
-    /**
-     * Set the data watcher.
-     * @param value - new value.
-    */
-    public void setMetadata(EntityMetadata value) {
-        handle.getDataWatcherModifier().write(0, value);
-    }
+
 }
 
 

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet18SpawnMob.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/Packet18SpawnMob.java
@@ -269,6 +269,14 @@ public class Packet18SpawnMob extends AbstractPacket {
     public void setMetadata(WrappedDataWatcher value) {
         handle.getDataWatcherModifier().write(0, value);
     }
+    
+    /**
+     * Set the data watcher.
+     * @param value - new value.
+    */
+    public void setMetadata(EntityMetadata value) {
+        handle.getDataWatcherModifier().write(0, value);
+    }
 }
 
 


### PR DESCRIPTION
Added an easy to use wrapper for entity metadata, because it can be hard to understand normally.
The class extends WrappedDataWatcher and adds all methods to get/set the metadata.
This currently works with the SpawnMob class and the SpawnNamedEntity class, but it can be used for all entities in the future.
Users will use this class when normally using WrappedDataWatcher, so it would look like setMetadata(EntityMetadata value);
I did some sample javadoc at the beginning, but it takes so much time to write.  I will finish it if you like the idea.
I am also planning to add enums for different types (villager, sheep, horse, etc) and the bit masks for mob flags (right now the class assumes the user know how to bitshift)
